### PR TITLE
Add `date_published` field to Feed Item

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,8 @@ export const generateRSS = (items: Item[], options: GenerateRSSOptions) => {
                     email: `${item.author.login}@noreply.github.com`
                 }
             ],
-            date: dayjs(item.createdAt).toDate()
+            published: dayjs(item.createdAt).toDate(),
+            date: dayjs(item.updatedAt).toDate()
         });
     });
     if (path.extname(options.link) === ".json") {


### PR DESCRIPTION
Adds an item's createdAt to the feed.  This shows up in the feed json as a `date_published`.

Here is where this option is referenced in the `feed` package: 
https://github.com/jpmonette/feed/blob/fd77835d23990670975092c15009c75432e258ac/src/json.ts#L67-L72

Here's an example feed json running on my fork: https://bensheldon.github.io/github-search-rss/rails-activejob.json

This is a fantastic project. Thank you!
