### PR TITLE
Add optional `homepage` option for `home_page_url` and proper `feed_url` feed values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export type GenerateRSSOptions = {
     title: string;
     description: string;
     link: string;
+    homepage?: string;
     image?: string;
     favicon?: string;
     updated: Date;
@@ -182,7 +183,8 @@ export const generateRSS = (items: Item[], options: GenerateRSSOptions) => {
         title: options.title,
         description: options.description,
         id: options.link,
-        link: options.link,
+        link: options.homepage || options.link,
+        feedLinks: { json: options.link },
         image: options.image,
         favicon: options.favicon,
         copyright: "github-search-rss",

--- a/src/rss.ts
+++ b/src/rss.ts
@@ -16,7 +16,8 @@ export const SEARCH_ITEMS: RSSItem[] = [
         title: "microsoft/TypeScript Iteration Plan",
         query: "repo:microsoft/TypeScript is:issue label:Planning",
         TYPE: "ISSUE",
-        link: `${BASE_URL}/typescript-iterator-plan.json`
+        link: `${BASE_URL}/typescript-iterator-plan.json`,
+        homepage: "https://github.com/search?q=repo%3Amicrosoft%2FTypeScript+is%3Aissue+label%3APlanning"
     },
     {
         title: "w3ctag/design-reviews Design Issues",


### PR DESCRIPTION
Separates out the feed's `feed_url` (the link to the feed) from the `home_page_url` (the resource that the feed describes e.g. the Github Search page itself).

Here's the implementation in the `feed` package: 
https://github.com/jpmonette/feed/blob/fd77835d23990670975092c15009c75432e258ac/src/json.ts#L16-L22

And the description of these values in the JSON Feed spec: 
https://www.jsonfeed.org/version/1.1/